### PR TITLE
Standalone - Support Availability Profiles served as sync files

### DIFF
--- a/status-computation/java/src/main/java/ar/EndpointTimelines.java
+++ b/status-computation/java/src/main/java/ar/EndpointTimelines.java
@@ -1,0 +1,187 @@
+package ar;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import myudf.AddTopology;
+import ops.DAggregator;
+import ops.DTimeline;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.DefaultDataBag;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+import sync.EndpointGroups;
+import sync.MetricProfiles;
+import utils.Slot;
+
+public class EndpointTimelines extends EvalFunc<Tuple> {
+
+    public DAggregator endpointAggr;
+	
+	private TupleFactory tupFactory; 
+    private BagFactory bagFactory;
+	
+    private DTimeline mt;
+    
+    
+	public String fnMetricProfiles;
+	public String fnOps;
+	
+	public String targetDate;
+	
+	public boolean initialized;
+	
+	public EndpointTimelines( String fnOps, String targetDate) throws IOException{
+		// set first the filenames
+		this.fnOps = fnOps;
+		
+		// set the targetDate var
+		this.targetDate = targetDate;
+	
+		// set the Structures
+		this.endpointAggr = new DAggregator();
+		
+		// set up factories
+		this.tupFactory = TupleFactory.getInstance();
+		this.bagFactory = BagFactory.getInstance();
+		
+		// this is not yet initialized because we need files from distributed cache
+		this.initialized = false;
+	}
+	
+	public void init() throws IOException
+	{
+		// Open Files from distributed cache
+		this.endpointAggr.opsMgr.openFile(new File("./ops"));
+		this.initialized=true;
+		System.out.println("Initialized!");
+	}
+	
+	public List<String> getCacheFiles() { 
+        List<String> list = new ArrayList<String>(); 
+        list.add(this.fnOps.concat("#ops"));
+        return list; 
+	} 
+	
+	
+	@Override
+	public Tuple exec(Tuple input) throws IOException {
+		
+		// Check if cache files have been opened 
+		if (this.initialized==false)
+        {
+        	this.init(); // If not open them 
+        }
+		
+		if (input == null || input.size() == 0) return null;
+		
+		///Grab endpoint info
+		String service = (String)input.get(0);
+		String hostname = (String)input.get(1);
+		// Get timeline info
+		DefaultDataBag bag =  (DefaultDataBag) input.get(2);
+		// Iterate the whole timeline
+		Iterator<Tuple> it_bag = bag.iterator();
+		
+		while (it_bag.hasNext()){
+	    	Tuple cur_item = it_bag.next();
+	    	//Get timeline item info
+	    	String metric = (String) cur_item.get(0);
+	    	String ts = (String) cur_item.get(1);
+	    	String status = (String) cur_item.get(2);
+	    	if (! ( ts.substring(0, ts.indexOf("T")).equals(this.targetDate)) ) {
+	    		this.endpointAggr.setStartState(metric, status);
+	    		continue;
+	    	}
+	    	
+	    	try {
+			
+	    		this.endpointAggr.insert(metric, ts, status);
+			
+	    	} catch (ParseException e) {
+				e.printStackTrace();
+			}
+	    	
+		}
+		
+		this.endpointAggr.finalizeAll();
+		this.endpointAggr.aggregate("AND"); // should be supplied on outside file
+		
+		//Create output Tuple
+	    Tuple output = tupFactory.newTuple();
+	    DataBag outBag = bagFactory.newDefaultBag();
+	    
+	    output.append(service);
+	    output.append(hostname);
+	    
+		//Append the timeline
+	    for (int i=0;i<this.endpointAggr.aggregation.samples.length;i++)  {
+	    	Tuple cur_tupl = tupFactory.newTuple();
+	    	cur_tupl.append(i);
+			cur_tupl.append(this.endpointAggr.aggregation.samples[i]);
+			outBag.add(cur_tupl);
+		}
+	    
+	    output.append(outBag);
+	    
+	    if (outBag.size()==0) return null;
+	   
+		return output;
+	    
+		
+		
+		
+		
+	}
+	
+	@Override
+    public Schema outputSchema(Schema input) {
+        
+		Schema.FieldSchema service = new Schema.FieldSchema("service", DataType.CHARARRAY);
+		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
+		
+		Schema.FieldSchema slot = new Schema.FieldSchema("slot", DataType.INTEGER);
+		Schema.FieldSchema statusInt = new Schema.FieldSchema("status", DataType.INTEGER);
+        
+        Schema endpoint = new Schema();
+        Schema timeline = new Schema();
+       
+        endpoint.add(service);
+        endpoint.add(hostname);
+        
+        timeline.add(slot);
+        timeline.add(statusInt);
+
+        Schema.FieldSchema tl = null;
+        try {
+            tl = new Schema.FieldSchema("timeline", timeline, DataType.BAG);
+        } catch (FrontendException ex) {
+           
+        }
+        
+        endpoint.add(tl);
+        
+        try {
+            return new Schema(new Schema.FieldSchema("endpoint", endpoint, DataType.TUPLE));
+        } catch (FrontendException ex) {
+           
+        }
+        
+        return null;
+    }
+	
+}

--- a/status-computation/java/src/main/java/ar/MetricTimelines.java
+++ b/status-computation/java/src/main/java/ar/MetricTimelines.java
@@ -1,0 +1,180 @@
+package ar;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import ops.DAggregator;
+import ops.DTimeline;
+import ops.OpsManager;
+
+import org.apache.pig.EvalFunc;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.DefaultDataBag;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+public class MetricTimelines extends EvalFunc<Tuple> {
+
+	private String fnOps; 
+	private String targetDate;
+	
+	private DTimeline dtl;
+	private OpsManager opsMgr;
+	
+	private TupleFactory tupFactory; 
+    private BagFactory bagFactory;
+	
+	private boolean initialized;
+	
+	public MetricTimelines ( String fnOps, String targetDate) throws IOException{
+		// set first the filenames
+		this.fnOps = fnOps;
+		
+		// set the targetDate var
+		this.targetDate = targetDate;
+	
+		// set the Structures
+		this.dtl = new DTimeline();
+		this.opsMgr = new OpsManager();
+		// set up factories
+		this.tupFactory = TupleFactory.getInstance();
+		this.bagFactory = BagFactory.getInstance();
+		// this is not yet initialized because we need files from distributed cache
+		this.initialized = false;
+	}
+	
+	public void init() throws IOException
+	{
+		// Open Files from distributed cache
+		this.opsMgr.openFile(new File("./ops"));
+		this.initialized=true;
+		System.out.println("Initialized!");
+	}
+	
+	public List<String> getCacheFiles() { 
+        List<String> list = new ArrayList<String>(); 
+        list.add(this.fnOps.concat("#ops"));
+        return list; 
+	} 
+	
+	
+	public Tuple exec(Tuple input) throws IOException {
+		
+		// Check if cache files have been opened 
+		if (this.initialized==false)
+        {
+        	this.init(); // If not open them 
+        }
+		
+		if (input == null || input.size() == 0) return null;
+		
+		///Grab endpoint info
+		String service = (String)input.get(0);
+		String hostname = (String)input.get(1);
+		String metric = (String)input.get(2);
+		// Get timeline info
+		DefaultDataBag bag =  (DefaultDataBag) input.get(3);
+		// Iterate the whole timeline
+		Iterator<Tuple> itBag = bag.iterator();
+		
+		while (itBag.hasNext()){
+	    	Tuple curItem = itBag.next();
+	    	//Get timeline item info
+	    	
+	    	String ts = (String) curItem.get(0);
+	    	String status = (String) curItem.get(1);
+	    	if (! ( ts.substring(0, ts.indexOf("T")).equals(this.targetDate)) ) {
+	    		this.dtl.setStartState(this.opsMgr.getIntStatus(status));
+	    		continue;
+	    	}
+	    	
+	    	try {
+			
+	    		this.dtl.insert(ts, opsMgr.getIntStatus(status));
+			
+	    	} catch (ParseException e) {
+				e.printStackTrace();
+			}
+	    	
+		}
+		
+		this.dtl.finalize();
+		
+		//Create output Tuple
+	    Tuple output = tupFactory.newTuple();
+	    DataBag outBag = bagFactory.newDefaultBag();
+	    
+	    output.append(service);
+	    output.append(hostname);
+	    output.append(metric);
+	    
+		//Append the timeline
+	    for (int i=0;i<this.dtl.samples.length;i++)  {
+	    	Tuple cur_tupl = tupFactory.newTuple();
+	    	cur_tupl.append(i);
+			cur_tupl.append(this.dtl.samples[i]);
+			outBag.add(cur_tupl);
+		}
+	    
+	    output.append(outBag);
+	    
+	    if (outBag.size()==0) return null;
+	   
+		return output;
+		
+		
+		
+		
+		
+	
+	}
+	
+	@Override
+    public Schema outputSchema(Schema input) {
+        
+		Schema.FieldSchema service = new Schema.FieldSchema("service", DataType.CHARARRAY);
+		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
+		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);
+		
+		Schema.FieldSchema slot = new Schema.FieldSchema("slot", DataType.INTEGER);
+		Schema.FieldSchema statusInt = new Schema.FieldSchema("status", DataType.INTEGER);
+        
+        Schema metricTl = new Schema();
+        Schema timeline = new Schema();
+       
+        metricTl.add(service);
+        metricTl.add(hostname);
+        metricTl.add(metric);
+        
+        timeline.add(slot);
+        timeline.add(statusInt);
+
+        Schema.FieldSchema tl = null;
+        try {
+            tl = new Schema.FieldSchema("timeline", timeline, DataType.BAG);
+        } catch (FrontendException ex) {
+           
+        }
+        
+        metricTl.add(tl);
+        
+        try {
+            return new Schema(new Schema.FieldSchema("endpoint", metricTl, DataType.TUPLE));
+        } catch (FrontendException ex) {
+           
+        }
+        
+        return null;
+    }
+
+	
+	
+}

--- a/status-computation/java/src/main/java/ar/PickEndpoints.java
+++ b/status-computation/java/src/main/java/ar/PickEndpoints.java
@@ -1,0 +1,82 @@
+package ar;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+import org.apache.pig.FilterFunc;
+import org.apache.pig.data.Tuple;
+
+import sync.EndpointGroups;
+import sync.MetricProfiles;
+
+public class PickEndpoints extends FilterFunc {
+    
+	public EndpointGroups endpoint_mgr;
+	public MetricProfiles metric_mgr;
+	
+	public String fnEndpointGroups;
+	public String fnMetricProfiles;
+	
+	public boolean initialized = false;
+	
+	public PickEndpoints(String fnEndpointGroups, String fnMetricProfiles) throws IOException{
+		// set first the filenames
+		this.fnEndpointGroups = fnEndpointGroups;
+		this.fnMetricProfiles = fnMetricProfiles;
+		// set the Structures
+		this.endpoint_mgr=new EndpointGroups();
+		this.metric_mgr = new MetricProfiles();
+		
+	}
+	
+	public void init() throws IOException
+	{
+		this.endpoint_mgr.loadAvro(new File("./endpoint_groups"));
+		this.metric_mgr.loadAvro(new File("./metric_profiles"));
+		this.initialized=true;
+	}
+	
+	public List<String> getCacheFiles() { 
+        List<String> list = new ArrayList<String>(); 
+        list.add(this.fnEndpointGroups.concat("#endpoint_groups"));
+        list.add(this.fnMetricProfiles.concat("#metric_profiles"));
+        return list; 
+	} 
+	
+	@Override
+    public Boolean exec(Tuple input) throws IOException {
+        if (this.initialized==false)
+        {
+        	this.init();
+        }
+		
+		if (input == null || input.size() == 0) return null;
+        
+        //Get Arguments
+        String hostname = (String)input.get(0);
+        String service = (String)input.get(1);
+        String metric = (String)input.get(2);
+        
+        //Only 1 profile per job
+        String prof = metric_mgr.getProfiles().get(0);
+        //Filter By profile First
+        if (metric_mgr.checkProfileServiceMetric(prof, service, metric) == false ) return null;
+        // Filter By topology
+        if (endpoint_mgr.checkEndpoint(hostname, service) == false) return null;
+        
+        
+        //Filter in the future by tags
+        
+        
+        return true;
+        
+    }
+	
+	
+	 
+	
+	
+}

--- a/status-computation/java/src/main/java/ar/PickEndpoints.java
+++ b/status-computation/java/src/main/java/ar/PickEndpoints.java
@@ -14,8 +14,8 @@ import sync.MetricProfiles;
 
 public class PickEndpoints extends FilterFunc {
     
-	public EndpointGroups endpoint_mgr;
-	public MetricProfiles metric_mgr;
+	public EndpointGroups endpointMgr;
+	public MetricProfiles metricMgr;
 	
 	public String fnEndpointGroups;
 	public String fnMetricProfiles;
@@ -27,15 +27,15 @@ public class PickEndpoints extends FilterFunc {
 		this.fnEndpointGroups = fnEndpointGroups;
 		this.fnMetricProfiles = fnMetricProfiles;
 		// set the Structures
-		this.endpoint_mgr=new EndpointGroups();
-		this.metric_mgr = new MetricProfiles();
+		this.endpointMgr=new EndpointGroups();
+		this.metricMgr = new MetricProfiles();
 		
 	}
 	
 	public void init() throws IOException
 	{
-		this.endpoint_mgr.loadAvro(new File("./endpoint_groups"));
-		this.metric_mgr.loadAvro(new File("./metric_profiles"));
+		this.endpointMgr.loadAvro(new File("./endpoint_groups"));
+		this.metricMgr.loadAvro(new File("./metric_profiles"));
 		this.initialized=true;
 	}
 	
@@ -61,12 +61,11 @@ public class PickEndpoints extends FilterFunc {
         String metric = (String)input.get(2);
         
         //Only 1 profile per job
-        String prof = metric_mgr.getProfiles().get(0);
-        //Filter By profile First
-        if (metric_mgr.checkProfileServiceMetric(prof, service, metric) == false ) return null;
-        // Filter By topology
-        if (endpoint_mgr.checkEndpoint(hostname, service) == false) return null;
-        
+        String prof = metricMgr.getProfiles().get(0);
+        //Filter By profile first
+        if (metricMgr.checkProfileServiceMetric(prof, service, metric) == false ) return null;
+        //Filter By topology
+        if (endpointMgr.checkEndpoint(hostname, service) == false) return null;
         
         //Filter in the future by tags
         

--- a/status-computation/java/src/main/java/ops/DAggregator.java
+++ b/status-computation/java/src/main/java/ops/DAggregator.java
@@ -14,7 +14,7 @@ public class DAggregator {
 	
 	public OpsManager opsMgr;
 	
-	DAggregator(){
+	public DAggregator(){
 		
 		this.timelines = new HashMap<String,DTimeline>();
 		this.aggregation = new DTimeline();
@@ -57,6 +57,14 @@ public class DAggregator {
 		}
 	}
 
+	public void finalizeAll()
+	{
+		for (Entry<String, DTimeline> item : timelines.entrySet())
+		{
+			item.getValue().finalize();
+		}
+	}
+	
 	public void aggregate(String opType) {
 		
 		int opTypeInt = this.opsMgr.getIntOperation(opType);

--- a/status-computation/java/src/main/java/ops/DAggregator.java
+++ b/status-computation/java/src/main/java/ops/DAggregator.java
@@ -9,10 +9,10 @@ import java.util.Map.Entry;
 
 public class DAggregator {
 	
-	private HashMap<String,DTimeline> timelines;
-	private DTimeline aggregation;
+	public HashMap<String,DTimeline> timelines;
+	public DTimeline aggregation;
 	
-	private OpsManager opsMgr;
+	public OpsManager opsMgr;
 	
 	DAggregator(){
 		
@@ -38,8 +38,9 @@ public class DAggregator {
 		else {
 			timelines.get(name).insert(timestamp, statusInt);
 		}
-		
 	}
+	
+	
 	
 	public void setStartState(String name, String status)
 	{
@@ -60,25 +61,23 @@ public class DAggregator {
 		
 		int opTypeInt = this.opsMgr.getIntOperation(opType);
 		
-		
 		for (int i=0;i<this.aggregation.samples.length;i++) {
 			
-			boolean first_item = true;
+			boolean firstItem = true;
 			
 			for (Entry<String, DTimeline> item : timelines.entrySet()) {
 				
-				if (first_item) {
+				if (firstItem) {
 					this.aggregation.samples[i] = item.getValue().samples[i];
+					firstItem = false;
 				}
 				else {
 					int a = this.aggregation.samples[i];
 					int b = item.getValue().samples[i];
 					this.aggregation.samples[i] = this.opsMgr.opInt(opTypeInt,a, b);
-				}
-				
+				}		
 			}
 		}
-		
 	}
 	
 		

--- a/status-computation/java/src/main/java/ops/DIntegrator.java
+++ b/status-computation/java/src/main/java/ops/DIntegrator.java
@@ -1,0 +1,5 @@
+package ops;
+
+public class DIntegrator {
+
+}

--- a/status-computation/java/src/main/java/ops/DTimeline.java
+++ b/status-computation/java/src/main/java/ops/DTimeline.java
@@ -18,7 +18,7 @@ public class DTimeline {
 	
 	public int[] samples;				// array of samples based on sampling frequency		
 	
-	DTimeline()	{
+	public DTimeline()	{
 		this.startState = -1;
 		this.sPeriod = 1440;			// 1 day = 24 hours = 24 * 60 minutes = 1440 minutes
 		this.sInterval = 5;				// every 5 minutes;
@@ -64,7 +64,13 @@ public class DTimeline {
 		
 		double total_minutes = Math.round(total_seconds/60.0);
 		double result = Math.round(total_minutes/this.sInterval);
-		return (int)result;
+		
+		if ((int) result == samples.length){
+			return (int) result-1;
+		} else
+		{
+			return (int)result;
+		}
 	}
 	
 	public void insert(String timestamp, int state ) throws ParseException{
@@ -78,7 +84,11 @@ public class DTimeline {
 		int prev_slot = 0;
 		for (int item : this.inputStates.keySet())
 		{
-			
+			if (item==0)
+			{
+				this.samples[item] = this.inputStates.get(item);
+				continue;
+			}
 			this.samples[item] = this.inputStates.get(item);
 			// fill previous states
 			for (int i=prev_slot;i<item-1;i++)

--- a/status-computation/java/src/main/java/ops/DTimeline.java
+++ b/status-computation/java/src/main/java/ops/DTimeline.java
@@ -9,11 +9,9 @@ import java.util.TreeMap;
 
 public class DTimeline {
 	
-	
-	
+
 	private int startState;	// state to define the beginning of the timeline  
 	private TreeMap<Integer,Integer> inputStates; // input states with the timestamp converted to slots
-	
 	
 	private int sPeriod;       // sampling period measured in minutes
 	private int sInterval;   	// sampling interval measured in minutes;
@@ -29,7 +27,6 @@ public class DTimeline {
 		Arrays.fill(samples, -1);
 	}
 	
-
 	public void setSampling(int period, int interval) {
 		this.sPeriod = period;
 		this.sInterval = interval;
@@ -45,7 +42,6 @@ public class DTimeline {
 		startState = -1;
 		inputStates.clear();
 	}
-
 	
 	public void setStartState(int state)
 	{
@@ -99,7 +95,6 @@ public class DTimeline {
 		{
 			this.samples[i] = prev_state;
 		}
-		
 		
 	}
 	

--- a/status-computation/java/src/main/java/ops/OpsManager.java
+++ b/status-computation/java/src/main/java/ops/OpsManager.java
@@ -25,7 +25,7 @@ public class OpsManager {
 	
 	private boolean order;
 	
-	OpsManager(){
+	public OpsManager(){
 		this.states = new HashMap<String,Integer>();
 		this.ops = new HashMap<String,Integer>();
 		this.revStates = new ArrayList<String>();
@@ -36,7 +36,7 @@ public class OpsManager {
 		this.order = false;;
 	}
 	
-	OpsManager(boolean _order){
+	public OpsManager(boolean _order){
 		this.states = new HashMap<String,Integer>();
 		this.ops = new HashMap<String,Integer>();
 		this.revStates = new ArrayList<String>();
@@ -58,11 +58,22 @@ public class OpsManager {
 	
 	public int opInt(int op,int a, int b)
 	{
-		return this.truthTable[op][a][b];
+		int result=-1;
+		try
+		{
+			result = this.truthTable[op][a][b];
+		}
+		catch (IndexOutOfBoundsException ex)
+		{
+			result = -1;
+		}
+		
+		return result;
 	}
 	
 	public int opInt(String op,String a, String b)
 	{
+		
 		int opInt = this.ops.get(op);
 		int aInt = this.states.get(a);
 		int bInt = this.states.get(b);

--- a/status-computation/java/src/main/java/sync/AvailabilityProfiles.java
+++ b/status-computation/java/src/main/java/sync/AvailabilityProfiles.java
@@ -4,7 +4,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map.Entry;
 
 import com.google.gson.JsonElement;
@@ -70,6 +72,119 @@ public class AvailabilityProfiles {
 		this.list.clear();
 	}
 	
+	// Return the available Group Names of a profile
+	public ArrayList<String> getProfileGroups(String avProfile) {
+			
+		if (this.list.containsKey(avProfile))
+		{
+			ArrayList<String> result = new ArrayList<String>();
+			Iterator<String> groupIterator = this.list.get(avProfile).groups.keySet().iterator();
+			
+			while (groupIterator.hasNext()) {
+				result.add(groupIterator.next());
+			}
+			
+			return result;
+		}
+		
+		return null;
+	}
+	
+	// Return the available group operation
+	public String getProfileGroupOp(String avProfile, String groupName)
+	{
+		if (this.list.containsKey(avProfile))
+		{
+			if (this.list.get("avProfile").groups.containsKey(groupName))
+			{
+				return this.list.get("avProfile").groups.get(groupName).op;
+			}
+		}
+		
+		return null;
+	}
+	
+	public ArrayList<String> getProfileGroupServices(String avProfile, String groupName){
+		if (this.list.containsKey(avProfile))
+		{
+			if (this.list.get(avProfile).groups.containsKey(groupName))
+			{
+				ArrayList<String> result = new ArrayList<String>();
+				Iterator<String> srvIterator = this.list.get(avProfile).groups.get(groupName).services.keySet().iterator();
+                
+				while (srvIterator.hasNext()) {
+					result.add(srvIterator.next());
+				}
+				
+				return result;
+			}
+		}
+		
+		return null;
+	}
+	
+	public String getProfileGroupServiceOp(String avProfile, String groupName, String service){
+		if (this.list.containsKey(avProfile))
+		{
+			if (this.list.get(avProfile).groups.containsKey(groupName))
+			{
+				if (this.list.get(avProfile).groups.get(groupName).services.containsKey(service))
+				{
+					return this.list.get(avProfile).groups.get(groupName).services.get(service);
+				}
+			}
+		}
+		
+		return null;
+	}
+	
+	public ArrayList<String> getAvProfiles(){
+		
+		if (this.list.size() > 0) {
+			ArrayList<String> result = new ArrayList<String>();
+			Iterator<String> avpIterator = this.list.keySet().iterator();
+			while (avpIterator.hasNext()) {
+				result.add(avpIterator.next());
+			}
+			
+			return result;
+			
+		}
+		
+		return null;
+	}
+	
+	public String getProfileNamespace(String avProfile){
+		
+		if (this.list.containsKey(avProfile))
+		{
+			return this.list.get(avProfile).namespace;
+		}
+		
+		return null;
+	}
+	
+	public String getProfileMetricProfile(String avProfile){
+		
+		if (this.list.containsKey(avProfile))
+		{
+			return this.list.get(avProfile).metricProfile;
+		}
+		
+		return null;
+	}
+	
+	public String getProfileGroupType(String avProfile){
+		
+		if (this.list.containsKey(avProfile))
+		{
+			return this.list.get(avProfile).groupType;
+		}
+		
+		return null;
+	}
+	
+	
 	public void loadProfileJson(File jsonFile) throws FileNotFoundException{
 		
 		BufferedReader br = new BufferedReader(new FileReader(jsonFile));
@@ -83,7 +198,7 @@ public class AvailabilityProfiles {
 		AvProfileItem tmpAvp = new AvProfileItem();
 		
 		tmpAvp.name= jRootObj.get("name").getAsString();
-		tmpAvp.namespace = jRootObj.get("group_type").getAsString();
+		tmpAvp.namespace = jRootObj.get("namespace").getAsString();
 		tmpAvp.metricProfile = jRootObj.get("metric_profile").getAsString();
 		tmpAvp.groupType = jRootObj.get("group_type").getAsString();
 		tmpAvp.op = jRootObj.get("operation").getAsString();
@@ -103,6 +218,9 @@ public class AvailabilityProfiles {
 			
 			
 		}
+		
+		//Add profile to the list
+		this.list.put(tmpAvp.name, tmpAvp);
 		
 		
 	}

--- a/status-computation/java/src/main/java/sync/AvailabilityProfiles.java
+++ b/status-computation/java/src/main/java/sync/AvailabilityProfiles.java
@@ -1,0 +1,111 @@
+package sync;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+
+public class AvailabilityProfiles {
+
+	private HashMap<String,AvProfileItem> list;
+	
+	
+	AvailabilityProfiles(){
+		
+		this.list = new HashMap<String,AvProfileItem>();
+	}
+	
+	private class AvProfileItem {
+			
+		private String name;
+		private String namespace;
+		private String metricProfile;
+		private String groupType;
+		private String op;
+		
+		private HashMap<String,ServGroupItem> groups;
+		
+		AvProfileItem(){
+			this.groups=new HashMap<String,ServGroupItem>();
+		}
+		
+		private class ServGroupItem{
+			
+			String op;
+			HashMap<String,String> services;
+			
+			ServGroupItem(String op)
+			{
+				this.op = op;
+				this.services = new HashMap<String,String>();
+			}
+		}
+		
+		// ServGroupItem Declaration Ends Here
+		
+		public void insertGroup(String group, String op){
+			if (!this.groups.containsKey(group))
+			{
+				this.groups.put(group, new ServGroupItem(op));
+			}
+		}
+		
+		public void insertService(String group, String service, String op) {
+			if (this.groups.containsKey(group))
+			{
+				this.groups.get(group).services.put(service, op);
+			}
+		}
+	}
+	// AvProfileItem Declaration Ends Here
+	
+	public void clearProfiles(){
+		this.list.clear();
+	}
+	
+	public void loadProfileJson(File jsonFile) throws FileNotFoundException{
+		
+		BufferedReader br = new BufferedReader(new FileReader(jsonFile));
+		JsonParser jsonParser = new JsonParser();
+		JsonElement jRootElement = jsonParser.parse(br);
+		JsonObject jRootObj = jRootElement.getAsJsonObject();
+		
+		JsonObject apGroups = jRootObj.getAsJsonObject("groups");
+		
+		// Create new entry for this availability profile
+		AvProfileItem tmpAvp = new AvProfileItem();
+		
+		tmpAvp.name= jRootObj.get("name").getAsString();
+		tmpAvp.namespace = jRootObj.get("group_type").getAsString();
+		tmpAvp.metricProfile = jRootObj.get("metric_profile").getAsString();
+		tmpAvp.groupType = jRootObj.get("group_type").getAsString();
+		tmpAvp.op = jRootObj.get("operation").getAsString();
+		
+		for (Entry<String,JsonElement> item : apGroups.entrySet()){
+			// service name
+			String itemName = item.getKey();
+			JsonObject itemObj = item.getValue().getAsJsonObject();
+			String itemOp = itemObj.get("operation").getAsString();
+			JsonObject itemServices = itemObj.get("services").getAsJsonObject();
+			tmpAvp.insertGroup(itemName,itemOp);
+			
+			for (Entry<String,JsonElement> subItem : itemServices.entrySet())
+			{
+				tmpAvp.insertService(itemName, subItem.getKey(),subItem.getValue().getAsString());
+			}
+			
+			
+		}
+		
+		
+	}
+	
+	
+}

--- a/status-computation/java/src/test/java/ops/DAggregatorTest.java
+++ b/status-computation/java/src/test/java/ops/DAggregatorTest.java
@@ -1,0 +1,83 @@
+package ops;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Arrays;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DAggregatorTest {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		// Assert that files are present
+		assertNotNull("Test file missing", DAggregatorTest.class.getResource("/ops/EGI-algorithm.json"));
+	}
+	
+	@Test
+	public void test() throws URISyntaxException, FileNotFoundException, ParseException {
+		
+		URL resJsonFile = OpsManagerTest.class.getResource("/ops/EGI-algorithm.json");
+		File jsonFile = new File(resJsonFile.toURI());
+		
+		DAggregator dAgg = new DAggregator();
+		dAgg.loadOpsFile(jsonFile);
+		
+		//Create 3 Timelines
+		DTimeline t1 = new DTimeline();
+		DTimeline t2 = new DTimeline();
+		DTimeline t3 = new DTimeline();
+		
+		t1.setSampling(1440, 120);
+		t2.setSampling(1440, 120);
+		t3.setSampling(1440, 120);
+		
+		dAgg.aggregation.setSampling(1440, 120);
+		
+		//Set First States
+		t1.setStartState(dAgg.opsMgr.getIntStatus("OK"));
+		t2.setStartState(dAgg.opsMgr.getIntStatus("UNKNOWN"));
+		t3.setStartState(dAgg.opsMgr.getIntStatus("OK"));
+		
+		//Add some timestamps int timeline 1
+		t1.insert("2014-01-15T01:33:44Z", dAgg.opsMgr.getIntStatus("CRITICAL"));
+		t1.insert("2014-01-15T05:33:01Z", dAgg.opsMgr.getIntStatus("OK"));
+		t1.insert("2014-01-15T12:50:42Z", dAgg.opsMgr.getIntStatus("WARNING"));
+		t1.insert("2014-01-15T15:33:44Z", dAgg.opsMgr.getIntStatus("OK"));
+		
+		//Add some timestamps int timeline 2
+		t2.insert("2014-01-15T05:33:44Z", dAgg.opsMgr.getIntStatus("OK"));
+		t2.insert("2014-01-15T08:33:01Z", dAgg.opsMgr.getIntStatus("MISSING"));
+		t2.insert("2014-01-15T12:50:42Z", dAgg.opsMgr.getIntStatus("CRITICAL"));
+		t2.insert("2014-01-15T19:33:44Z", dAgg.opsMgr.getIntStatus("UNKNOWN"));
+		
+		//Add some timestamps int timeline 2
+		t3.insert("2014-01-15T04:00:44Z", dAgg.opsMgr.getIntStatus("WARNING"));
+		t3.insert("2014-01-15T09:33:01Z", dAgg.opsMgr.getIntStatus("CRITICAL"));
+		t3.insert("2014-01-15T12:50:42Z", dAgg.opsMgr.getIntStatus("OK"));
+		t3.insert("2014-01-15T16:33:44Z", dAgg.opsMgr.getIntStatus("WARNING"));
+		
+		t1.finalize();
+		t2.finalize();
+		t3.finalize();
+		
+		dAgg.timelines.put("timeline1", t1);
+		dAgg.timelines.put("timeline2", t2);
+		dAgg.timelines.put("timeline3", t3);
+		
+		
+		dAgg.aggregate("OR");
+		
+		int[] expected = {0,1,0,0,0,0,0,0,0,0,0,0};
+		// Check the arrays
+		assertArrayEquals("Aggregation check",expected,dAgg.aggregation.samples);
+		
+		
+	}
+}

--- a/status-computation/java/src/test/java/ops/DAggregatorTest.java
+++ b/status-computation/java/src/test/java/ops/DAggregatorTest.java
@@ -79,5 +79,53 @@ public class DAggregatorTest {
 		assertArrayEquals("Aggregation check",expected,dAgg.aggregation.samples);
 		
 		
+		
+		
+		
+		
+	}
+	
+	@Test
+	public void test2() throws URISyntaxException, FileNotFoundException, ParseException {
+		
+		URL resJsonFile = OpsManagerTest.class.getResource("/ops/EGI-algorithm.json");
+		File jsonFile = new File(resJsonFile.toURI());
+		
+		DAggregator dAgg = new DAggregator();
+		dAgg.loadOpsFile(jsonFile);
+		
+		dAgg.setStartState("m1", "OK");
+		dAgg.setStartState("m2", "OK");
+		dAgg.setStartState("m3", "OK");
+		dAgg.setStartState("m4", "OK");
+		dAgg.insert("m1", "2014-01-15T00:00:00Z", "CRITICAL");
+		dAgg.insert("m1", "2014-01-15T04:33:44Z", "CRITICAL");
+		dAgg.insert("m1", "2014-01-15T06:33:44Z", "CRITICAL");
+		dAgg.insert("m1", "2014-01-15T12:33:44Z", "CRITICAL");
+		dAgg.insert("m1", "2014-01-15T22:11:44Z", "CRITICAL");
+		dAgg.insert("m2", "2014-01-15T01:33:44Z", "CRITICAL");
+		dAgg.insert("m2", "2014-01-15T05:33:44Z", "CRITICAL");
+		dAgg.insert("m2", "2014-01-15T06:33:44Z", "CRITICAL");
+		dAgg.insert("m2", "2014-01-15T22:33:44Z", "CRITICAL");
+		dAgg.insert("m3", "2014-01-15T01:33:44Z", "CRITICAL");
+		dAgg.insert("m3", "2014-01-15T05:33:44Z", "CRITICAL");
+		dAgg.insert("m3", "2014-01-15T11:33:44Z", "CRITICAL");
+		dAgg.insert("m4", "2014-01-15T01:33:44Z", "WARNING");
+		dAgg.insert("m4", "2014-01-15T02:33:44Z", "OK");
+		dAgg.insert("m4", "2014-01-15T24:59:59Z", "CRITICAL");
+		
+	
+		
+		dAgg.finalizeAll();
+		dAgg.aggregate("AND");
+		
+		System.out.println(Arrays.toString(dAgg.aggregation.samples));
+		
+		
+		
+		
+		
+		
+		
 	}
 }

--- a/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
+++ b/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
@@ -76,7 +76,7 @@ public class AvailabilityProfilesTest {
 		expServices.add("Site-BDII");
 		assertEquals("accounting  list",avp.getProfileGroupServices("ap1", "information"),expServices);
 		
-		// Check Varuous Service Instances operation
+		// Check Various Service Instances operation
 		assertEquals("group compute: CREAM-CE op",avp.getProfileGroupServiceOp("ap1", "compute", "CREAM-CE"),"AND");
 		assertEquals("group compute: ARC-CE op",avp.getProfileGroupServiceOp("ap1", "compute", "ARC-CE"),"AND");
 		assertEquals("group storage: SRMv2 op",avp.getProfileGroupServiceOp("ap1", "storage", "SRM"),"AND");

--- a/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
+++ b/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
@@ -1,0 +1,91 @@
+package sync;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+
+import ops.OpsManager;
+import ops.OpsManagerTest;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AvailabilityProfilesTest {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		// Assert that files are present
+		assertNotNull("Test file missing", AvailabilityProfilesTest.class.getResource("/ops/ap1.json"));
+	}
+	
+	@Test
+	public void test() throws URISyntaxException, FileNotFoundException {
+		//Prepare Resource File
+		URL resJsonFile = OpsManagerTest.class.getResource("/ops/ap1.json");
+		File jsonFile = new File(resJsonFile.toURI());
+		// Instatiate class
+		AvailabilityProfiles avp = new AvailabilityProfiles();
+		avp.clearProfiles();
+		avp.loadProfileJson(jsonFile);
+	   
+		// Check that only one availability profile was loaded
+		assertEquals("Only 1 av profile present",avp.getAvProfiles().size(),1);
+		
+		ArrayList<String> expApList = new ArrayList<String>();
+		expApList.add("ap1");
+		
+		// Check the profile list is correct
+		assertEquals("Profile list check",avp.getAvProfiles(),expApList);
+		
+		// Check the profile namespace
+		assertEquals("Profile namespace",avp.getProfileNamespace("ap1"),"test");
+		
+		// Check the profile groupType
+		assertEquals("Profile group type",avp.getProfileGroupType("ap1"),"sites");
+		
+		// Set the expected profile groups
+		ArrayList<String> expGroups = new ArrayList<String>();
+		expGroups.add("information");
+		expGroups.add("compute");
+		expGroups.add("storage");
+		// Check the available group list
+		assertEquals("Profile Groups",avp.getProfileGroups("ap1"),expGroups);
+		
+		// Check compute group service list
+		ArrayList<String> expServices = new ArrayList<String>();
+		expServices.add("GRAM5");
+		expServices.add("QCG.Computing");
+		expServices.add("ARC-CE");
+		expServices.add("unicore6.TargetSystemFactory");
+		expServices.add("CREAM-CE");
+        
+		assertEquals("compute service list",avp.getProfileGroupServices("ap1", "compute"),expServices);
+        
+		// Check storage group service list
+		expServices = new ArrayList<String>();
+		expServices.add("SRM");
+		expServices.add("SRMv2");
+		assertEquals("storage service list",avp.getProfileGroupServices("ap1", "storage"),expServices);
+		
+		// Check storage group service list
+		expServices = new ArrayList<String>();
+		expServices.add("Site-BDII");
+		assertEquals("accounting  list",avp.getProfileGroupServices("ap1", "information"),expServices);
+		
+		// Check Varuous Service Instances operation
+		assertEquals("group compute: CREAM-CE op",avp.getProfileGroupServiceOp("ap1", "compute", "CREAM-CE"),"AND");
+		assertEquals("group compute: ARC-CE op",avp.getProfileGroupServiceOp("ap1", "compute", "ARC-CE"),"AND");
+		assertEquals("group storage: SRMv2 op",avp.getProfileGroupServiceOp("ap1", "storage", "SRM"),"AND");
+		assertEquals("group storage: SRM op",avp.getProfileGroupServiceOp("ap1", "storage", "SRMv2"),"AND");
+		assertEquals("group information: Site-BDII op",avp.getProfileGroupServiceOp("ap1", "information", "Site-BDII"),"AND");
+		// we check for an unexpected operation
+		assertNotEquals("group compute: CREAM-CE op",avp.getProfileGroupServiceOp("ap1", "compute", "CREAM-CE"),"OR");
+	
+       
+	}
+
+}

--- a/status-computation/java/src/test/resources/ops/EGI-ar.json
+++ b/status-computation/java/src/test/resources/ops/EGI-ar.json
@@ -1,0 +1,11 @@
+{
+  "counters":{
+    "up":["OK","WARNING"],
+    "unknown":["UNKNOWN","MISSING"],
+    "downtime":["DOWNTIME"]
+  },
+  "computations":{
+    "availability":"(up/t) - (1.0 - (unknown / t))",
+    "reliability":"(up/t) - (1.0 - (unknown / t) - (downtime/t))"
+  }
+}

--- a/status-computation/java/src/test/resources/ops/ap1.json
+++ b/status-computation/java/src/test/resources/ops/ap1.json
@@ -1,0 +1,34 @@
+{
+  
+  "name": "ap1",
+  "namespace": "test",
+  "metric_profile": "ch.cern.sam.ROC_CRITICAL",
+  "group_type": "sites",
+  "operation":"AND",
+  "groups": {
+    "compute": {
+      "services":{
+        "CREAM-CE":"AND",
+        "ARC-CE":"AND",
+        "GRAM5":"AND",
+        "unicore6.TargetSystemFactory":"AND",
+        "QCG.Computing":"AND"
+        },
+       "operation":"OR"
+    },
+    "storage": {
+      "services":{
+        "SRM":"AND",
+        "SRMv2":"AND"
+        },
+       "operation":"OR"
+    },
+    "accounting": {
+      "services":{
+        "Site-BDII":"AND"
+        },
+       "operation":"OR"
+    }
+    
+  } 
+}

--- a/status-computation/java/src/test/resources/ops/ap1.json
+++ b/status-computation/java/src/test/resources/ops/ap1.json
@@ -23,7 +23,7 @@
         },
        "operation":"OR"
     },
-    "accounting": {
+    "information": {
       "services":{
         "Site-BDII":"AND"
         },

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -1,0 +1,65 @@
+REGISTER /usr/libexec/ar-compute/lib/piggybank.jar
+REGISTER /usr/libexec/ar-compute/lib/avro-1.7.4.jar
+REGISTER /usr/libexec/ar-compute/lib/jackson-core-asl-1.8.8.jar
+REGISTER /usr/libexec/ar-compute/lib/jackson-mapper-asl-1.8.8.jar
+REGISTER /usr/libexec/ar-compute/lib/snappy-java-1.0.4.1.jar
+REGISTER /usr/libexec/ar-compute/lib/json-simple-1.1.jar
+
+REGISTER /usr/libexec/ar-compute/lib/mongo-hadoop-core.jar
+REGISTER /usr/libexec/ar-compute/lib/mongo-hadoop-pig.jar
+REGISTER /usr/libexec/ar-compute/lib/mongo-java-driver-2.11.4.jar
+
+REGISTER /usr/libexec/ar-compute/dude/MyUDF.jar
+
+DEFINE f_PickEndpoints ar.PickEndpoints('$endpoint_groups','$metric_profile');
+DEFINE f_EndpointTl ar.EndpointTimelines('$ops','$dt');
+DEFINE f_MetricTl ar.MetricTimelines('$ops','$dt');
+
+
+--- Get One Day Before metric data in ordet to get past status references 
+p_mdata = LOAD '$p_mdata' using org.apache.pig.piggybank.storage.avro.AvroStorage();
+p_mdata_trim = FOREACH p_mdata GENERATE  service, hostname, metric, timestamp, status;
+p_mdata_clean = FILTER p_mdata_trim BY f_PickEndpoints(hostname,service,metric);
+
+
+--- Produce the latest previous statuses as references
+p_ref = FOREACH (GROUP p_mdata_clean BY (service,hostname,metric)) {
+	timeline = ORDER p_mdata_clean by timestamp DESC;
+	big_t = limit timeline 1;
+	GENERATE FLATTEN(big_t) as (service,hostname,metric,timestamp,status);
+};
+
+--- Get Target Day metric data 
+mdata= LOAD '$mdata' using org.apache.pig.piggybank.storage.avro.AvroStorage();
+mdata_trim = FOREACH mdata GENERATE  service, hostname, metric, timestamp, status;
+mdata_clean = FILTER mdata_trim BY f_PickEndpoints(hostname,service,metric);
+
+--- Union previous mdata with current 
+mdata_full = UNION mdata_clean,p_ref;
+
+
+
+metric_tline_raw  = FOREACH (GROUP mdata_full BY (service,hostname,metric)){
+	t = ORDER mdata_full by timestamp ASC;
+	generate group.service, group.hostname, group.metric, t.(status);
+}
+
+store metric_tline_raw into './log/metric_tline_raw';
+
+/*
+
+metric_tlines = FOREACH (GROUP mdata_full BY (service,hostname,metric)){
+	t = ORDER mdata_full by timestamp ASC;
+	generate f_MetricTl(group.service, group.hostname, group.metric, t.(timestamp, status));
+}
+
+-- Group by service,hostname to create endpoint timelines
+endpoints =	FOREACH  (GROUP mdata_full BY (service,hostname)) {
+	GENERATE FLATTEN(f_EndpointTl(group.service, group.hostname, mdata_full.(metric,timestamp,status)));
+};
+
+
+store metric_tline_raw into './log/metric_tline_raw';
+store metric_tlines into './log/metric_tlines';
+store endpoints into './log/endpoints';
+*/

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -44,9 +44,6 @@ metric_tline_raw  = FOREACH (GROUP mdata_full BY (service,hostname,metric)){
 	generate group.service, group.hostname, group.metric, t.(status);
 }
 
-store metric_tline_raw into './log/metric_tline_raw';
-
-/*
 
 metric_tlines = FOREACH (GROUP mdata_full BY (service,hostname,metric)){
 	t = ORDER mdata_full by timestamp ASC;
@@ -62,4 +59,3 @@ endpoints =	FOREACH  (GROUP mdata_full BY (service,hostname)) {
 store metric_tline_raw into './log/metric_tline_raw';
 store metric_tlines into './log/metric_tlines';
 store endpoints into './log/endpoints';
-*/


### PR DESCRIPTION
Availability profiles can now be supplied in json file form along with the other sync files.

the .json file also includes definitions of operations to take place between instances of the same service type (for eg. ORing , or ANDing or FOOing between  a site's CREAM-CE's). 