### PR TITLE
Config file fix typo

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -1,7 +1,7 @@
 Name: ar-compute
 Summary: A/R Comp Engine core scripts
 Version: 1.6.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -66,6 +66,8 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
+* Mon Mar 02 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.0-6%{?dist}
+- Fix typo in ar-compute-engine.conf 
 * Fri Feb 27 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.0-5%{?dist}
 - Fix config filenames. Add More Verbosity
 - Correct Cloudmon job name in global config

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -32,7 +32,7 @@ s_interval=5
 
 [datastore_mapping]
 
-e_map=dt,ap,p,s,n,hsp,a,r,up,u,d,m,pr,ss,cs,i,sc
+e_map=dt,ap,p,s,n,hs,a,r,up,u,d,m,pr,ss,cs,i,sc
 s_map=dt,ap,p,s,n,sf,a,r,up,u,d,m,pr,ss,cs,i,sc
 sd_map=ts,s,sum,msg,ps,pts,di,ti
 n_eg=site


### PR DESCRIPTION
Scripts ran successfully on devel. The only thing found was a typo in the ar-compute-engine.conf

Please merge